### PR TITLE
Initialize incremental value cache if it hasn't been initialized yet

### DIFF
--- a/src/collaboration/shared.js
+++ b/src/collaboration/shared.js
@@ -68,12 +68,12 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
     await store.start()
     const [loadedState, loadedDeltas, clock] = await store.load()
     if (loadedState) {
-      if (crdtType.incrementalValue) {
+      if (crdtType.incrementalValue && !options.replicateOnly) {
         assert(!valueCache)
         valueCache = crdtType.incrementalValue(state, loadedState, loadedState)
       }
       state = loadedState
-    } else if (crdtType.incrementalValue) {
+    } else if (crdtType.incrementalValue && !options.replicateOnly) {
       assert(!valueCache)
       valueCache = crdtType.incrementalValue(state, state, state)
     }

--- a/src/collaboration/shared.js
+++ b/src/collaboration/shared.js
@@ -210,7 +210,12 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
     } else {
       const newState = crdtType.join.call(changeEmitter, state, s)
       if (crdtType.incrementalValue) {
-        valueCache = crdtType.incrementalValue(state, newState, s, valueCache)
+        if (!valueCache) {
+          const initial = crdtType.initial()
+          valueCache = crdtType.incrementalValue(initial, newState, newState, valueCache)
+        } else {
+          valueCache = crdtType.incrementalValue(state, newState, s, valueCache)
+        }
       }
       state = newState
       shared.emit('delta', s, fromSelf)


### PR DESCRIPTION
Handle case where state is already loaded before apply is called.

Needed to fix editing issues after page reload in PeerPad. https://github.com/ipfs-shipyard/peer-pad/issues/273

(sorry, no test)