### PR TITLE
Fix missing spread operator in isDeltaInteresting

### DIFF
--- a/src/common/vectorclock.js
+++ b/src/common/vectorclock.js
@@ -38,7 +38,7 @@ exports.isDeltaInteresting = (delta, currentClock) => {
   const [previousClock, authorClock] = delta
 
   // find out if previous clock is inside currentClock
-  const authors = new Set([...Object.keys(currentClock), Object.keys(previousClock)])
+  const authors = new Set([...Object.keys(currentClock), ...Object.keys(previousClock)])
   for (let author of authors) {
     if ((previousClock[author] || 0) > (currentClock[author] || 0)) {
       return false


### PR DESCRIPTION
This was causing deltas to be applied when the underlying state
didn't exist yet...

This was causing corruption in PeerPad. I was able to debug this
thanks to the runtime checks from this patch:

https://github.com/ipfs-shipyard/js-delta-crdts/pull/34