### PR TITLE
Several fixes for push / pull protocols

### DIFF
--- a/src/collaboration/index.js
+++ b/src/collaboration/index.js
@@ -24,8 +24,14 @@ const defaultOptions = {
   resetConnectionIntervalMS: 6000,
   maxUnreachableBeforeEviction: 10,
   replicateOnly: false,
-  debouncePushMS: 500,
+  // Wait this long before pushing changes to other peers, so that we can merge
+  // many changes that happen in a short space of time together
+  debouncePushMS: 100,
+  // Max amount of time to wait
+  debouncePushMaxMS: 1000,
+  // Same as above but for pushing to a pinner
   debouncePushToPinnerMS: 5000,
+  debouncePushToPinnerMaxMS: 10000,
   receiveTimeoutMS: 3000,
   saveDebounceMS: 3000
 }

--- a/src/collaboration/index.js
+++ b/src/collaboration/index.js
@@ -18,7 +18,7 @@ const debounce = require('lodash/debounce')
 const defaultOptions = {
   preambleByteCount: 2,
   peerIdByteCount: 32,
-  debounceResetConnectionsMS: 1000,
+  debounceResetConnectionsMS: 0,
   maxDeltaRetention: 1000,
   deltaTrimTimeoutMS: 1000,
   resetConnectionIntervalMS: 6000,
@@ -96,6 +96,7 @@ class Collaboration extends EventEmitter {
     this.shared.on('state changed', debounce((fromSelf) => {
       fromSelf = fromSelf || changeFromSelf
       changeFromSelf = false
+
       this.emit('state changed', fromSelf)
     }, 0))
 

--- a/src/collaboration/index.js
+++ b/src/collaboration/index.js
@@ -81,9 +81,6 @@ class Collaboration extends EventEmitter {
 
     this.shared = Shared(name, selfId, this._type, this._ipfs, this, this._clocks, this._options)
     this.shared.on('error', (err) => this.emit('error', err))
-    this.shared.on('clock changed', (clock) => {
-      this._clocks.setFor(selfId, clock)
-    })
 
     // state changed
 

--- a/src/collaboration/index.js
+++ b/src/collaboration/index.js
@@ -18,7 +18,7 @@ const debounce = require('lodash/debounce')
 const defaultOptions = {
   preambleByteCount: 2,
   peerIdByteCount: 32,
-  debounceResetConnectionsMS: 0,
+  debounceResetConnectionsMS: 1000,
   maxDeltaRetention: 1000,
   deltaTrimTimeoutMS: 1000,
   resetConnectionIntervalMS: 6000,

--- a/src/collaboration/peer-to-clock-id.js
+++ b/src/collaboration/peer-to-clock-id.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const b58Decode = require('bs58').decode
+const radix64 = require('radix-64')()
+
+// Decoding the id results in a 34 byte buffer, so cut it down to the last
+// 8 bytes, then radix64 encode to fit it efficiently into a string
+module.exports = (peerId) => {
+  const buff = b58Decode(peerId)
+  return radix64.encodeBuffer(buff.slice(buff.length - 8))
+}

--- a/src/collaboration/pull-protocol.js
+++ b/src/collaboration/pull-protocol.js
@@ -85,7 +85,7 @@ module.exports = class PullProtocol {
         if (!states && !delta) {
           waitTimers.onClock(clock, () => {
             // If the timer expires, switch to eager mode
-            dbg('switching to eager mode')
+            dbg('switching to eager mode with peer %s', remotePeerId)
             remote.setEagerMode()
           })
           return
@@ -124,9 +124,7 @@ module.exports = class PullProtocol {
           this._replication.received(remotePeerId, clock)
           dbg('saved with new clock %j', saved)
         } else {
-          // There was no new information in the state / delta, so switch to
-          // lazy mode
-          dbg('did not save, setting %s to lazy mode', remotePeerId)
+          dbg('did not save, setting connection to %s to lazy mode', remotePeerId)
           remote.setLazyMode()
         }
       }).catch(onEnd)

--- a/src/collaboration/pull-protocol.js
+++ b/src/collaboration/pull-protocol.js
@@ -22,38 +22,47 @@ module.exports = class PullProtocol {
   }
 
   forPeer (peerInfo) {
+    const dbg = (...args) => debug('%s: ' + args[0], this._peerId(), ...args.slice(1))
     const remotePeerId = peerInfo.id.toB58String()
-    debug('%s: pull protocol to %s', this._peerId(), remotePeerId)
+    dbg('pull protocol to %s', remotePeerId)
+
+    const waitTimers = this._waitTimers(dbg)
     const queue = new Queue({ concurrency: 1 })
     let ended = false
-    let waitingForClock = null
-    let timeout
+    // Is the remote peer a pinner
     let isPinner
 
+    // When the local state is changed, send a clock to the remote peer to let
+    // them know
     const onNewLocalClock = (clock) => {
-      debug('%s got new clock from state:', this._peerId(), clock)
+      dbg('local state mutation, new clock:', clock)
       // TODO: only send difference from previous clock
       this._clocks.setFor(this._peerId(), clock)
-      output.push(encode([clock]))
+      remote.sendClock(clock)
     }
     this._shared.on('clock changed', onNewLocalClock)
 
-    const onNewData = (data) => {
-      debug('%s got new data from %s :', this._peerId(), remotePeerId, data)
+    // Handle incoming message from remote peer
+    const messageHandler = (data) => {
+      dbg('got new message from %s: %j', remotePeerId, data)
 
       queue.add(async () => {
-        const [deltaRecord, newStates, peerInfo] = data
+        const [deltaRecord, newStates, protocolPeerInfo] = data
 
-        if (peerInfo && peerInfo.isPinner && !isPinner) {
+        // If the remote peer indicates that it is a pinner, tell it to go into lazy mode
+        if (protocolPeerInfo && protocolPeerInfo.isPinner && !isPinner) {
+          dbg('remote peer %s is a pinner, switching to lazy mode', remotePeerId)
           isPinner = true
-          output.push(encode([null, true]))
+          remote.setLazyMode()
           return
         }
 
+        // The remote will send us either deltas or the full state
         let clock
         let states
         let delta
         if (deltaRecord) {
+          // If we receive deltas, work out what the clock should be
           const [previousClock, authorClock] = deltaRecord
           delta = deltaRecord[2]
           clock = vectorclock.sumAll(previousClock, authorClock)
@@ -62,79 +71,66 @@ module.exports = class PullProtocol {
           states = newStates[1]
         }
 
-        if (clock) {
-          clock = this._clocks.setFor(remotePeerId, clock)
-          if (states || delta) {
-            this._replication.receiving(remotePeerId, clock)
-            if (waitingForClock &&
-                (vectorclock.isIdentical(waitingForClock, clock) ||
-                 vectorclock.compare(waitingForClock, clock) < 0)) {
-              // We received what we were waiting for, so we can clear the timeout
-              waitingForClock = null
-              if (timeout) {
-                clearTimeout(timeout)
-              }
-            }
-            debug('%s: received clock from %s: %j', this._peerId(), remotePeerId, clock)
+        // We didn't get a clock, so we can't make any assumptions, bail out
+        if (Object.keys(clock || {}).length === 0) {
+          dbg('did not receive clock from %s, bailing out', remotePeerId)
+          return
+        }
 
-            let saved
-            if (states) {
-              debug('%s: saving states', this._peerId(), states)
-              const rootState = states.get(null)
-              if (!rootState) {
-                throw new Error('expected root state')
-              }
-              const decryptedRootState = await this._decryptAndVerifyDelta(rootState)
-              const saved = await this._shared.apply(decryptedRootState, false)
-              if (saved) {
-                for (let [collabName, collabState] of states) {
-                  if (collabName === null) {
-                    continue // already processed root state
-                  }
-                  await this._shared.apply(await this._decryptAndVerifyDelta(collabState), false, true)
-                }
-              } else {
-                output.push(encode([null, true]))
-              }
-            } else if (delta) {
-              debug('%s: saving delta', this._peerId(), deltaRecord)
-              saved = await this._shared.apply(await this._decryptAndVerifyDelta(deltaRecord), true)
-            }
-            if (!saved) {
-              debug('%s: did not save', this._peerId())
-              debug('%s: setting %s to lazy mode (2)', this._peerId(), remotePeerId)
-              output.push(encode([null, true]))
-            } else {
-              this._replication.received(remotePeerId, clock)
-              debug('%s: saved with new clock %j', this._peerId(), saved)
-            }
-          } else {
-            // Only got the vector clock, which means that this connection
-            //   is on lazy mode.
-            // We must wait a bit to see if we get the data this peer has
-            //   from any other peer.
-            // If not, we should engage eager mode
-            waitingForClock = vectorclock.merge(waitingForClock || {}, clock)
-            if (timeout) {
-              clearTimeout(timeout)
-              timeout = null
-            }
-            timeout = setTimeout(() => {
-              timeout = null
-              // are we still waiting for this clock?
-              if (waitingForClock &&
-                  (vectorclock.isIdentical(waitingForClock, clock) ||
-                  vectorclock.compare(waitingForClock, clock) < 0)) {
-                debug('%s: timeout happened for clock', this._peerId(), waitingForClock)
-                output.push(encode([null, false, true]))
-              }
-            }, this._options.receiveTimeoutMS)
-            // timeout and maybe turn into eager mode?
+        // Merge the remote peer's vector clock into our copy of it
+        clock = this._clocks.setFor(remotePeerId, clock)
+        dbg('received clock from %s: %j', remotePeerId, clock)
+
+        // We didn't get any state information, just a clock. So set a timer
+        // to wait for the data corresponding to this clock to arrive
+        if (!states && !delta) {
+          waitTimers.onClock(clock, () => {
+            // If the timer expires, switch to eager mode
+            dbg('switching to eager mode')
+            remote.setEagerMode()
+          })
+          return
+        }
+
+        // If we received states or a delta, the connection is in eager mode.
+        // Clear any timers that were waiting for data subsumed by this clock
+        waitTimers.onData(clock)
+        this._replication.receiving(remotePeerId, clock)
+
+        // Save the state / delta
+        let saved
+        if (states) {
+          dbg('saving states', states)
+          const rootState = states.get(null)
+          if (!rootState) {
+            throw new Error('expected root state')
           }
+
+          const decryptedRootState = await this._decryptAndVerifyDelta(rootState)
+          saved = await this._shared.apply(decryptedRootState, false)
+          if (saved) {
+            for (let [collabName, collabState] of states) {
+              if (collabName === null) {
+                continue // already processed root state
+              }
+              await this._shared.apply(await this._decryptAndVerifyDelta(collabState), false, true)
+            }
+          }
+        } else if (delta) {
+          dbg('saving delta %j', deltaRecord)
+          saved = await this._shared.apply(await this._decryptAndVerifyDelta(deltaRecord), true)
+        }
+
+        if (saved) {
+          this._replication.received(remotePeerId, clock)
+          dbg('saved with new clock %j', saved)
+        } else {
+          // There was no new information in the state / delta, so switch to
+          // lazy mode
+          dbg('did not save, setting %s to lazy mode', remotePeerId)
+          remote.setLazyMode()
         }
       }).catch(onEnd)
-
-      return true // keep the stream alive
     }
 
     const onData = (err, data) => {
@@ -143,14 +139,8 @@ module.exports = class PullProtocol {
         return
       }
 
-      onNewData(data)
+      messageHandler(data)
     }
-
-    const onCollaborationStopped = () => {
-      onEnd()
-    }
-
-    this._collaboration.on('stopped', onCollaborationStopped)
 
     const onEnd = (err) => {
       if (!ended) {
@@ -160,17 +150,20 @@ module.exports = class PullProtocol {
         }
         ended = true
         this._shared.removeListener('clock changed', onNewLocalClock)
-        this._collaboration.removeListener('stopped', onCollaborationStopped)
-        output.end(err)
+        this._collaboration.removeListener('stopped', onEnd)
+        waitTimers.stop()
+        remote.end(err)
       }
     }
+    this._collaboration.on('stopped', onEnd)
+
+    const remote = this._remote()
     const input = pull.drain(handlingData(onData), onEnd)
-    const output = pushable()
 
     const vectorClock = this._shared.clock()
-    output.push(encode([vectorClock, null, null, this._options.replicateOnly || false]))
+    remote.init(vectorClock, this._options.replicateOnly || false)
 
-    return { sink: input, source: output }
+    return { sink: input, source: remote.output }
   }
 
   _peerId () {
@@ -180,15 +173,113 @@ module.exports = class PullProtocol {
     return this._cachedPeerId
   }
 
+  _remote () {
+    const output = pushable()
+
+    return {
+      output,
+      send (msg) {
+        // [clock, startLazy, startEager, isLocalPinner]
+        output.push(encode(msg))
+      },
+      sendClock (clock) {
+        this.send([clock])
+      },
+      setLazyMode () {
+        this.send([null, true])
+      },
+      setEagerMode () {
+        this.send([null, false, true])
+      },
+      init (clock, isLocalPinner) {
+        this.send([clock, null, null, isLocalPinner])
+      },
+      end (err) {
+        output.end(err)
+      }
+    }
+  }
+
+  _waitTimers (dbg) {
+    const receiveTimeoutMS = this._options.receiveTimeoutMS
+    const queue = new Queue({ concurrency: 1 })
+    const timers = new Map()
+    let running = true
+
+    const localHasClock = (clock) => {
+      const localClock = this._clocks.getFor(this._peerId())
+      return vectorclock.doesSecondHaveFirst(clock, localClock)
+    }
+
+    return {
+      onClock (clock, onTimeout) {
+        queue.add(() => {
+          if (!running) return
+
+          // Check if the remote has information we don't have
+          if (localHasClock(clock)) {
+            dbg('local already has clock, ignoring')
+            return
+          }
+
+          // Make sure we aren't already waiting for this clock
+          for (const c of timers.keys()) {
+            if (vectorclock.isIdentical(c, clock)) {
+              dbg('already waiting for data for clock, ignoring')
+              return
+            }
+          }
+
+          dbg('waiting for data for clock %j', clock)
+          const timeout = setTimeout(() => {
+            // Check if we've received the data for the clock
+            if (!localHasClock(clock)) {
+              dbg('did not receive data within %dms for clock %j', receiveTimeoutMS, clock)
+              running && onTimeout()
+            }
+          }, receiveTimeoutMS)
+
+          timers.set(clock, timeout)
+        })
+      },
+
+      onData (clock) {
+        queue.add(() => {
+          if (!running) return
+
+          // Check each timer to see if we've received the corresponding data
+          for (const [c, timeout] of [...timers]) {
+            if (vectorclock.doesSecondHaveFirst(c, clock)) {
+              dbg('received data - clearing timeout for clock %j', c)
+              clearTimeout(timeout)
+              timers.delete(c)
+            }
+          }
+        })
+      },
+
+      stop () {
+        dbg('stopping wait timers')
+        running = false
+        queue.add(() => {
+          for (const timeout of timers.values()) {
+            clearTimeout(timeout)
+          }
+          timers.clear()
+        })
+      }
+    }
+  }
+
   async _decryptAndVerifyDelta (deltaRecord) {
     const [previousClock, authorClock, [forName, typeName, encryptedDelta]] = deltaRecord
-    let decrytedDelta
+    let decryptedDelta
     if (this._options.replicateOnly) {
-      decrytedDelta = encryptedDelta
+      decryptedDelta = encryptedDelta
     } else {
-      decrytedDelta = decode(await this._decryptAndVerify(encryptedDelta))
+      decryptedDelta = decode(await this._decryptAndVerify(encryptedDelta))
     }
-    return [previousClock, authorClock, [forName, typeName, decrytedDelta]]
+    return [previousClock, authorClock, [forName, typeName, decryptedDelta]]
   }
 
   _decryptAndVerify (encrypted) {

--- a/src/collaboration/pull-protocol.js
+++ b/src/collaboration/pull-protocol.js
@@ -35,7 +35,6 @@ module.exports = class PullProtocol {
     const onNewLocalClock = (clock) => {
       dbg('local state mutation, new clock:', clock)
       // TODO: only send difference from previous clock
-      this._clocks.setFor(this._peerId(), clock)
       remote.sendClock(clock)
     }
     this._shared.on('clock changed', onNewLocalClock)

--- a/src/collaboration/push-protocol.js
+++ b/src/collaboration/push-protocol.js
@@ -152,12 +152,17 @@ module.exports = class PushProtocol {
     // Check if the remote peer needs an update
     const reduceEntropy = async () => {
       await isPinnerPromise()
+      if (queue.size >= 2) {
+        return
+      }
       queue.add(() => {
         dbg('reduceEntropy to %s', remotePeerId)
         if (remoteNeedsUpdate()) {
           return updateRemote(this._shared.clock())
         }
-        dbg('remote is up to date')
+
+        dbg('remote is up to date, just sending clock')
+        sendClockDiff()
       }).catch(onEnd)
     }
     const debouncedReduceEntropy = debounce(reduceEntropy, this._options.debouncePushMS, {

--- a/src/collaboration/push-protocol.js
+++ b/src/collaboration/push-protocol.js
@@ -13,6 +13,7 @@ const expectedNetworkError = require('../common/expected-network-error')
 const EventEmitter = require('events')
 const isUndefined = require('lodash/isUndefined')
 const pEvent = require('p-event')
+const peerToClockId = require('./peer-to-clock-id')
 
 // const RGA = require('delta-crdts').type('rga')
 // const chai = require('chai')
@@ -74,7 +75,7 @@ module.exports = class PushProtocol {
 
     // Send deltas to the remote peer
     const pushDeltaBatches = async (peerClock) => {
-      const batches = this._shared.deltaBatches(peerClock)
+      const batches = this._shared.deltaBatches(peerClock, remotePeerId)
       let newRemoteClock = {}
       for (let batch of batches) {
         const [clock, authorClock] = batch
@@ -134,7 +135,7 @@ module.exports = class PushProtocol {
       const myClock = _myClock || this._shared.clock()
       const remoteClock = _remoteClock || this._clocks.getFor(remotePeerId)
       dbg('comparing local clock %j to remote clock %j', myClock, remoteClock)
-      const needs = !vectorclock.doesSecondHaveFirst(myClock, remoteClock)
+      const needs = vectorclock.doesRemoteNeedUpdate(myClock, remoteClock, peerToClockId(remotePeerId))
       dbg('remote %s needs update? %s', remotePeerId, needs)
       return needs && myClock
     }

--- a/src/collaboration/push-protocol.js
+++ b/src/collaboration/push-protocol.js
@@ -164,8 +164,9 @@ module.exports = class PushProtocol {
       }
       queue.add(() => {
         dbg('reduceEntropy to %s', remotePeerId)
-        if (remoteNeedsUpdate()) {
-          return updateRemote(this._shared.clock())
+        const myClock = this._shared.clock()
+        if (remoteNeedsUpdate(myClock, remoteClock)) {
+          return updateRemote(myClock)
         }
 
         if (this._options.replicateOnly) {

--- a/src/collaboration/push-protocol.js
+++ b/src/collaboration/push-protocol.js
@@ -231,15 +231,17 @@ module.exports = class PushProtocol {
 
       // If the remote sent us its clock, update our local copy
       if (newRemoteClock) {
+        let clock
         if (isPinner) {
           // If the remote is a pinner, assume its clock is authoritative
           remoteClock = newRemoteClock
+          clock = this._clocks.setFor(remotePeerId, newRemoteClock)
         } else {
           // If the remote is a regular peer, just merge in the remote clock
           remoteClock = vectorclock.merge(remoteClock, newRemoteClock)
+          clock = this._clocks.mergeFor(remotePeerId, newRemoteClock)
         }
-        const mergedClock = this._clocks.setFor(remotePeerId, newRemoteClock, true, isPinner)
-        this._replication.sent(remotePeerId, mergedClock, isPinner)
+        this._replication.sent(remotePeerId, clock, isPinner)
       }
 
       // We have a new clock from the remote peer, so check if we need to send

--- a/src/collaboration/push-protocol.js
+++ b/src/collaboration/push-protocol.js
@@ -171,7 +171,6 @@ module.exports = class PushProtocol {
     // eager mode) to the remote peer
     const onClockChanged = (newClock) => {
       dbg('clock changed to %j', newClock)
-      this._clocks.setFor(this._peerId(), newClock)
       isPinner ? debouncedReduceEntropyToPinner() : debouncedReduceEntropy()
     }
     this._shared.on('clock changed', onClockChanged)

--- a/src/collaboration/shared.js
+++ b/src/collaboration/shared.js
@@ -181,13 +181,9 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
   shared.deltaBatches = (_since = {}) => {
     let since = _since
     const deltas = shared.deltas(since)
-    if (!deltas.length) {
-      return [[since, {}, [name, crdtType.typeName, crdtType.initial()]]]
-    }
 
     let batch = [since, {}, [name, crdtType.typeName, crdtType.initial()]]
-    const batches = [batch]
-
+    const batches = []
     deltas
       .forEach((deltaRecord) => {
         if (!vectorclock.isDeltaInteresting(deltaRecord, since)) {
@@ -217,6 +213,9 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
         batch[0] = newPreviousClock
         batch[1] = newAuthorClock
         batch[2][2] = newDelta
+        if (!batches.length) {
+          batches.push(batch)
+        }
       })
 
     return batches

--- a/src/collaboration/shared.js
+++ b/src/collaboration/shared.js
@@ -38,7 +38,7 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
       const authorClock = vectorclock.increment({}, clockId)
       const deltaRecord = [previousClock, authorClock, [name, crdtType.typeName, delta]]
       pushDelta(deltaRecord)
-      shared.emit('clock changed', newClock)
+      onClockChanged(newClock)
     } else {
       collaboration.parent.shared.pushDeltaForSub(name, crdtType.typeName, delta)
       apply(delta, true)
@@ -114,7 +114,7 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
     const authorClock = vectorclock.increment({}, clockId)
     const deltaRecord = [previousClock, authorClock, [name, type, delta]]
     pushDelta(deltaRecord)
-    shared.emit('clock changed', newClock)
+    onClockChanged(newClock)
   }
 
   shared.apply = (deltaRecord, isPartial, force) => {
@@ -141,7 +141,7 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
     }
     if (forName === name) {
       apply(delta)
-      shared.emit('clock changed', newClock)
+      onClockChanged(newClock)
       return newClock
     } else if (typeName) {
       return collaboration.sub(forName, typeName)
@@ -250,6 +250,11 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
 
     shared.emit('state changed', fromSelf)
     return state
+  }
+
+  function onClockChanged (newClock) {
+    clocks.setFor(id, newClock)
+    shared.emit('clock changed', newClock)
   }
 }
 

--- a/src/collaboration/shared.js
+++ b/src/collaboration/shared.js
@@ -76,7 +76,7 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
       deltas = loadedDeltas
     }
     if (clock) {
-      clocks.setFor(id, clock)
+      clocks.mergeFor(id, clock)
     }
   }
 
@@ -253,7 +253,7 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
   }
 
   function onClockChanged (newClock) {
-    clocks.setFor(id, newClock)
+    clocks.mergeFor(id, newClock)
     shared.emit('clock changed', newClock)
   }
 }

--- a/src/common/vectorclock.js
+++ b/src/common/vectorclock.js
@@ -34,7 +34,13 @@ exports.increment = (clock, author) => {
   return Object.assign({}, clock)
 }
 
-exports.isDeltaInteresting = (delta, currentClock) => {
+// A delta is interesting if
+// 1. The delta starts inside the current clock
+// 2. The delta ends outside the current clock
+//
+// Optionally you can supply peerClockId to ignore changes for the given peer
+// (useful when we don't want to send a peer its own changes)
+exports.isDeltaInteresting = (delta, currentClock, peerClockId) => {
   const [previousClock, authorClock] = delta
 
   // find out if previous clock is inside currentClock
@@ -47,8 +53,11 @@ exports.isDeltaInteresting = (delta, currentClock) => {
 
   // find out if new clock lands outside of current clock
   Object.keys(authorClock).forEach((author) => authors.add(author))
-  const deltaClock = exports.sumAll(previousClock, authorClock)
 
+  // If a target peer clock id was supplied, ignore changes to that id
+  authors.delete(peerClockId)
+
+  const deltaClock = exports.sumAll(previousClock, authorClock)
   for (let author of authors) {
     if ((deltaClock[author] || 0) > (currentClock[author] || 0)) {
       return true
@@ -58,14 +67,40 @@ exports.isDeltaInteresting = (delta, currentClock) => {
   return false
 }
 
+// Does the second replica have all the information that the first replica has?
 exports.doesSecondHaveFirst = (first, second) => {
   const keys = new Set([...Object.keys(first), ...Object.keys(second)])
+
+  // If the value for a particular key is smaller in the second vector clock,
+  // then the second replica needs some information that the first replica has
   for (let key of keys) {
     if ((second[key] || 0) < (first[key] || 0)) {
       return false
     }
   }
+
+  // Second replica has all the information that the first replica has
   return true
+}
+
+// Does the remote replica need information that the local replica has?
+exports.doesRemoteNeedUpdate = (local, remote, remoteClockId) => {
+  const keys = new Set([...Object.keys(local), ...Object.keys(remote)])
+
+  // Ignore remote's clock id because we assume that remote knows about any
+  // changes that it made
+  keys.delete(remoteClockId)
+
+  // If the value for a particular key is smaller in the remote vector clock,
+  // then the remote replica needs some information that the local replica has
+  for (let key of keys) {
+    if ((remote[key] || 0) < (local[key] || 0)) {
+      return true
+    }
+  }
+
+  // Remote replica has all the information that the local replica has
+  return false
 }
 
 exports.sumAll = (clock, authorClock) => {

--- a/test/collaboration-random.spec.js
+++ b/test/collaboration-random.spec.js
@@ -60,15 +60,17 @@ describe('collaboration with random changes', function () {
     const expectedCharacterCount = charsPerPeer * collaborations.length
     let expectedValue
     const modifications = async (collaboration, index) => {
-      const stateChangesSettled = debounceEvent(collaboration, 'state changed', process.browser ? 30000 : 10000)
+      const receivedAllChars = pEvent(collaboration, 'state changed', () => {
+        return collaboration.shared.value().length === expectedCharacterCount
+      })
       for (let i = 0; i < charsPerPeer; i++) {
         const character = characterFrom(manyCharacters, i)
         collaboration.shared.push(character)
         await delay(randomShortTime())
       }
 
-      // Wait for state changes to complete and for things to settle
-      await stateChangesSettled
+      // Wait for collaboration to receive all characters
+      await receivedAllChars
 
       const value = collaboration.shared.value()
       expect(value.length).to.equal(expectedCharacterCount)

--- a/test/collaboration-random.spec.js
+++ b/test/collaboration-random.spec.js
@@ -60,17 +60,15 @@ describe('collaboration with random changes', function () {
     const expectedCharacterCount = charsPerPeer * collaborations.length
     let expectedValue
     const modifications = async (collaboration, index) => {
-      const receivedAllChars = pEvent(collaboration, 'state changed', () => {
-        return collaboration.shared.value().length === expectedCharacterCount
-      })
+      const stateChangesSettled = debounceEvent(collaboration, 'state changed', process.browser ? 30000 : 10000)
       for (let i = 0; i < charsPerPeer; i++) {
         const character = characterFrom(manyCharacters, i)
         collaboration.shared.push(character)
         await delay(randomShortTime())
       }
 
-      // Wait for collaboration to receive all characters
-      await receivedAllChars
+      // Wait for state changes to complete and for things to settle
+      await stateChangesSettled
 
       const value = collaboration.shared.value()
       expect(value.length).to.equal(expectedCharacterCount)

--- a/test/collaboration-random.spec.js
+++ b/test/collaboration-random.spec.js
@@ -60,6 +60,7 @@ describe('collaboration with random changes', function () {
     let expectedCharacterCount = 0
     let expectedValue
     const modifications = async (collaboration, index) => {
+      const stateChangesSettled = debounceEvent(collaboration, 'state changed', process.browser ? 30000 : 10000)
       for (let i = 0; i < charsPerPeer; i++) {
         const character = characterFrom(manyCharacters, i)
         collaboration.shared.push(character)
@@ -67,7 +68,8 @@ describe('collaboration with random changes', function () {
         await delay(randomShortTime())
       }
 
-      await debounceEvent(collaboration, 'state changed', process.browser ? 30000 : 10000)
+      // Wait for state changes to complete and for things to settle
+      await stateChangesSettled
 
       const value = collaboration.shared.value()
       expect(value.length).to.equal(expectedCharacterCount)

--- a/test/collaboration-random.spec.js
+++ b/test/collaboration-random.spec.js
@@ -9,7 +9,6 @@ const delay = require('delay')
 const PeerStar = require('../')
 const App = require('./utils/create-app')
 const waitForMembers = require('./utils/wait-for-members')
-const debounceEvent = require('./utils/debounce-event')
 const b58Decode = require('bs58').decode
 const radix64 = require('radix-64')()
 const pEvent = require('p-event')

--- a/test/collaboration-random.spec.js
+++ b/test/collaboration-random.spec.js
@@ -136,7 +136,9 @@ describe('collaboration with random changes', function () {
         for (let replica of peerClockKeys) {
           // Ignore own key because remote may not send us updates about ourself
           if (replica !== collabPeerIdAsClockId && clock.hasOwnProperty(replica)) {
-            expect(clock[replica]).to.equal(charsPerPeer)
+            const msg = `${collaborationPeerId}'s copy of clock for ${peerId}` +
+              `has value ${clock[replica]} for key ${replica} (should be ${charsPerPeer})`
+            expect(clock[replica]).to.equal(charsPerPeer, msg)
           }
         }
       }

--- a/test/collaboration-random.spec.js
+++ b/test/collaboration-random.spec.js
@@ -9,7 +9,6 @@ const delay = require('delay')
 const PeerStar = require('../')
 const App = require('./utils/create-app')
 const waitForMembers = require('./utils/wait-for-members')
-const debounceEvent = require('./utils/debounce-event')
 const peerToClockId = require('../src/collaboration/peer-to-clock-id')
 
 const debug = require('debug')('peer-base:test:collaboration-random')
@@ -103,7 +102,7 @@ describe('collaboration with random changes', function () {
         return new Promise(resolve => {
           let complete = false
           collaboration._clocks.on('update', () => {
-            if(complete) {
+            if (complete) {
               return
             }
             if (checkCollaborationClocks(collaboration)) {
@@ -137,9 +136,6 @@ describe('collaboration with random changes', function () {
         for (let replica of peerClockKeys) {
           // Ignore own key because remote may not send us updates about ourself
           if (replica !== collabPeerIdAsClockId && clock.hasOwnProperty(replica)) {
-            if (clock[replica] !== charsPerPeer) {
-              console.error('%s copy of clock for %s is %d (should be %d)', collaborationPeerId, peerId, clock[replica], charsPerPeer)
-            }
             expect(clock[replica]).to.equal(charsPerPeer)
           }
         }

--- a/test/pinner.spec.js
+++ b/test/pinner.spec.js
@@ -96,20 +96,17 @@ describe('pinner', function () {
   it('waits for pinned event', (done) => {
     let pinned = false
 
-    const interval = setInterval(() => {
-      collaborations.forEach((collaboration, idx) => {
-        collaboration.shared.add(idx)
-      })
-    }, 50)
-
     collaborations.forEach((collaboration) => {
       collaboration.replication.once('pinned', () => {
         if (!pinned) {
           pinned = true
-          clearInterval(interval)
           done()
         }
       })
+    })
+
+    collaborations.forEach((collaboration, idx) => {
+      collaboration.shared.add(idx)
     })
   })
 


### PR DESCRIPTION
Fixes:
- When pull protocol received a clock, it would set a timer to wait for the corresponding data for the clock. But each time it received a new clock it would keep extending that timer. Now it sets a different timer per clock, and clears that timer only when data is received with a new clock that subsumes the one we were waiting for.
- It now cancels timers when the pull protocol is ended
- Pull protocol would switch to lazy mode whenever it received state, even if the state wasn't actually saved. This change makes it more judicious
- Push protocol now waits until it receives a message indicating whether the remote peer is a pinner before sending data. This helps avoid the scenario where we send deltas to a pinner instead of the full state (the pinner doesn't understand deltas because it doesn't have the encryption key, it only stores blobs)
- Reduce messages and connection downgrade (to lazy mode) by checking if the only change in the vector clock is to the recipient peer
- Reduce duplicate messages by merging remote clock instead of just setting it
- Remove extraneous batches from shared.deltaBatches()
- Only send messages switching between eager / lazy mode if not already in that mode
- Removed some dead code