### PR TITLE
fix: when push protocol resumes pushing, reset the remote clock

### DIFF
--- a/src/collaboration/push-protocol.js
+++ b/src/collaboration/push-protocol.js
@@ -226,8 +226,11 @@ module.exports = class PushProtocol {
         // from the remote clock.
         const overwriteRemoteClock = isPinner || (!wasPushing && pushing)
         if (overwriteRemoteClock) {
-          remoteClock = newRemoteClock
-          clock = this._clocks.setFor(remotePeerId, newRemoteClock)
+          queue.clear()
+          queue.add(() => {
+            remoteClock = newRemoteClock
+            clock = this._clocks.setFor(remotePeerId, newRemoteClock)
+          })
         } else {
           // If the remote is a regular peer, just merge in the remote clock
           remoteClock = vectorclock.merge(remoteClock, newRemoteClock)

--- a/src/collaboration/push-protocol.js
+++ b/src/collaboration/push-protocol.js
@@ -187,6 +187,7 @@ module.exports = class PushProtocol {
     // Handle incoming message from remote peer
     const messageHandler = (message) => {
       dbg('got message from %s:', remotePeerId, message)
+      const wasPushing = pushing
       const [newRemoteClock, startLazy, startEager, _isPinner] = message
 
       // Switch to lazy mode
@@ -220,8 +221,11 @@ module.exports = class PushProtocol {
       // If the remote sent us its clock, update our local copy
       if (newRemoteClock) {
         let clock
-        if (isPinner) {
-          // If the remote is a pinner, assume its clock is authoritative
+        // If the remote is a pinner, assume its clock is authoritative.
+        // If remote is asking us to start pushing, we're going to start
+        // from the remote clock.
+        const overwriteRemoteClock = isPinner || (!wasPushing && pushing)
+        if (overwriteRemoteClock) {
           remoteClock = newRemoteClock
           clock = this._clocks.setFor(remotePeerId, newRemoteClock)
         } else {

--- a/test/collaboration/membership-gossip-frequency-heuristic.spec.js
+++ b/test/collaboration/membership-gossip-frequency-heuristic.spec.js
@@ -75,7 +75,7 @@ describe('membership gossip frequency heuristic', () => {
 
     await eventManager.awaitNextEvent()
     const thirdReceived = Date.now()
-    expect(secondReceived - firstReceived).to.be.lte(150)
+    expect(thirdReceived - secondReceived).to.be.lte(150)
 
     heuristic.stop()
   })


### PR DESCRIPTION
When the remote puller tells a pusher to start pushing, the pusher should assume the given remote clock is the required clock, and thus should overwrite it instead of merging it.

This should account for the case when:

1)  the pusher was pushing changes that were being ignored by the puller
2) then it receives a "stop pushing" message,
3) then it receives a "start pushing" message.

In this case, pusher has fast-forwarded the clock while in state 1, and should reset when in 3.