### PR TITLE
Fix batch delta dependencies

### DIFF
--- a/src/collaboration/clocks.js
+++ b/src/collaboration/clocks.js
@@ -3,6 +3,7 @@
 const debug = require('debug')('peer-base:collaboration:clocks')
 const EventEmitter = require('events')
 const vectorclock = require('../common/vectorclock')
+const peerToClockId = require('./peer-to-clock-id')
 
 module.exports = class Clocks extends EventEmitter {
   constructor (id, options) {
@@ -31,7 +32,7 @@ module.exports = class Clocks extends EventEmitter {
   }
 
   getFor (peerId) {
-    return this._clocks.get(peerId) || {}
+    return this._clocks.get(peerId) || { [peerToClockId(peerId)]: 0 }
   }
 
   takeDown (peerId) {

--- a/src/collaboration/shared.js
+++ b/src/collaboration/shared.js
@@ -163,9 +163,9 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
     return (vectorclock.compare(otherClock, clock) < 0) || vectorclock.isIdentical(otherClock, clock)
   }
 
-  shared.deltas = (since = {}, targetPeerId) => {
+  shared.deltas = (since = {}) => {
     return deltas.filter((deltaRecord) => {
-      if (vectorclock.isDeltaInteresting(deltaRecord, since, targetPeerId)) {
+      if (vectorclock.isDeltaInteresting(deltaRecord, since)) {
         const [previousClock, authorClock] = deltaRecord
         since = vectorclock.merge(since, vectorclock.sumAll(previousClock, authorClock))
         return true
@@ -174,43 +174,59 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
     })
   }
 
-  shared.deltaBatches = (_since = {}, targetPeerId) => {
+  shared.deltaBatches = (_since = {}) => {
     let since = _since
-    const deltas = shared.deltas(since, targetPeerId)
+    const deltas = shared.deltas(since)
     let mainBatch
     const batches = []
-    deltas.forEach((deltaRecord) => {
-      const [deltaPreviousClock, deltaAuthorClock, [deltaName, , delta]] = deltaRecord
-      if (deltaName !== name) {
-        if (mainBatch) {
-          mainBatch = undefined
+    try {
+      deltas.forEach((deltaRecord) => {
+        const [deltaPreviousClock, deltaAuthorClock, [deltaName, , delta]] = deltaRecord
+        if (deltaName !== name) {
+          if (mainBatch) {
+            mainBatch = undefined
+          }
+          batches.push(deltaRecord)
+          return
         }
-        batches.push(deltaRecord)
-        return
+
+        // main batch
+        if (!mainBatch) {
+          mainBatch = deltaRecord
+          batches.push(mainBatch)
+          return
+        }
+
+        const [oldPreviousClock, oldAuthorClock, [, , oldDelta]] = mainBatch
+
+        // join delta with current batch
+        const oldClock = vectorclock.sumAll(oldPreviousClock, oldAuthorClock)
+        const deltaClock = vectorclock.sumAll(deltaPreviousClock, deltaAuthorClock)
+        const newClock = vectorclock.merge(oldClock, deltaClock)
+
+        const newPreviousClock = vectorclock.minimum(oldPreviousClock, deltaPreviousClock)
+        if (!vectorclock.doesSecondHaveFirst(_since, newPreviousClock)) {
+          const rewind = new Error('Broaden search to earlier clock')
+          rewind.since = newPreviousClock
+          throw rewind
+        }
+
+        const newAuthorClock = vectorclock.subtract(newPreviousClock, newClock)
+
+        const newDelta = crdtType.join.call(voidChangeEmitter, oldDelta, delta)
+
+        mainBatch[0] = newPreviousClock
+        mainBatch[1] = newAuthorClock
+        mainBatch[2][2] = newDelta
+      })
+    } catch (e) {
+      if (e.message === 'Broaden search to earlier clock') {
+        debug('rewind', e.since)
+        return shared.deltaBatches(e.since)
+      } else {
+        throw e
       }
-
-      // main batch
-      if (!mainBatch) {
-        mainBatch = deltaRecord
-        batches.push(mainBatch)
-        return
-      }
-
-      const [oldPreviousClock, oldAuthorClock, [, , oldDelta]] = mainBatch
-
-      // join delta with current batch
-      const oldClock = vectorclock.sumAll(oldPreviousClock, oldAuthorClock)
-      const deltaClock = vectorclock.sumAll(deltaPreviousClock, deltaAuthorClock)
-      const newClock = vectorclock.merge(oldClock, deltaClock)
-      const newPreviousClock = vectorclock.minimum(oldPreviousClock, deltaPreviousClock)
-      const newAuthorClock = vectorclock.subtract(newPreviousClock, newClock)
-
-      const newDelta = crdtType.join.call(voidChangeEmitter, oldDelta, delta)
-
-      mainBatch[0] = newPreviousClock
-      mainBatch[1] = newAuthorClock
-      mainBatch[2][2] = newDelta
-    })
+    }
 
     return batches
   }

--- a/src/common/vectorclock.js
+++ b/src/common/vectorclock.js
@@ -118,7 +118,13 @@ exports.minimum = (a, b) => {
   const keys = new Set([...Object.keys(a), ...Object.keys(b)])
   const result = {}
   for (let key of keys) {
-    result[key] = Math.min((a[key] || 0), (b[key] || 0))
+    if (a[key] === undefined) {
+      result[key] = b[key]
+    } else if (b[key] === undefined) {
+      result[key] = a[key]
+    } else {
+      result[key] = Math.min(a[key], b[key])
+    }
   }
 
   return result

--- a/test/collaboration-random.spec.js
+++ b/test/collaboration-random.spec.js
@@ -12,11 +12,25 @@ const AppFactory = require('./utils/create-app')
 const debug = require('debug')('peer-base:test:collaboration-random')
 
 describe('collaboration with random changes', function () {
-  const peerCount = process.browser ? 10 : 15
-  const charsPerPeer = 6
+  const peerCount = process.browser ? 10 : 10
+  const charsPerPeer = 30
   this.timeout(20000 * peerCount)
 
-  const manyCharacters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'.split('')
+  const manyCharacters = (
+    'abcdefghijklmnopqrstuvwxyz' +
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZ' +
+    '1234567890' +
+    'ÀÈÌÒÙ' +
+    'àèìòù' +
+    'ÁÉÍÓÚÝ' +
+    'áéíóúý' +
+    'ÂÊÎÔÛ' +
+    'âêîôû' +
+    'ÃÑÕ' +
+    'ãñõ' +
+    'ÄËÏÖÜŸ' +
+    'äëïöüÿ'
+  ).split('')
 
   const collaborationOptions = {}
 
@@ -139,7 +153,7 @@ describe('collaboration with random changes', function () {
     }
 
     function randomShortTime () {
-      return Math.floor((1 / Math.log(Math.random() * 5 + 1.02) * 50) + 10)
+      return Math.floor((1 / Math.log(Math.random() * 5 + 1.015) * 20) + 10)
     }
 
     function characterFrom (characters, index) {

--- a/test/collaboration/membership-gossip-frequency-heuristic.spec.js
+++ b/test/collaboration/membership-gossip-frequency-heuristic.spec.js
@@ -75,7 +75,7 @@ describe('membership gossip frequency heuristic', () => {
 
     await eventManager.awaitNextEvent()
     const thirdReceived = Date.now()
-    expect(secondReceived - firstReceived).to.be.lte(150)
+    expect(thirdReceived - firstReceived).to.be.lte(150)
 
     heuristic.stop()
   })

--- a/test/vectorclock.spec.js
+++ b/test/vectorclock.spec.js
@@ -240,10 +240,10 @@ describe('vectorclock', () => {
     ],
     minimum: [
       {},
-      { a: 0 },
-      { a: 0 },
-      { a: 0, b: 0, c: 0, d: 0 },
-      { a: 0, b: 1, c: 0 }
+      { a: 1 },
+      { a: 1 },
+      { a: 1, b: 2, c: 1, d: 2 },
+      { a: 1, b: 1, c: 2 }
     ],
     subtract: [
       {},


### PR DESCRIPTION
When creating batches, make sure all deltas are included

In high concurrency situations, often times delta will arrive that depend
on other deltas.

Right now, when we bundle deltas together into batches to send to
other peers, we are creating a clock for the batch that claims to
include all the deltas from a previous clock + an author clock, but
it is omitting any deltas that are dependencies of the ones that
are selected. As a result, when other peers receive the batch, they
will advance their vector clock ... but we currently have a problem,
because if they don't already have the dependencies missing from
the batch, they will never attempt to sync them.

This patch modifies the batch algorithm to check the previous clock
for the batch ... if new dependencies are added, when we compare it
to the 'since' clock that we are searching against, it will have
more content - so we restart the search for deltas with the wider
criteria so that we catch all the deltas.

There probably should be an additional check at the end of the
process to ensure that the author clocks add up, in case some of
the dependency deltas were trimmed and were not available.

A different approach would be to just abort creating the batch when
new dependencies are discovered (at the cost of creating more
work at the replication level).

In some situations, there might be several deltas stored that might
match the vector clock range used in constructing a batch (eg. the
original deltas, plus any intermediate batches). Right now, the
search algorithm just picks the first one that "is interesting".
I think that is okay, as the first one in the array is probably
going to be the smaller original delta.

 In order to "rewind" the search when we need to include more
 dependencies, I decided to throw an exception ... the logic was
 complicated because of the way the batches array is constructed
 due to sub-collaboration support. It could probably be rewritten
 to be more efficient.

Also, I changed vectorclock.minimum so it doesn't default to zero
as the minimum for the clocks... eg. before, if one clock was '2',
and the other was '3', the minimum would be zero. For the algorithm
here to work, it needs to be '2' ... which is consistent to what
you'd expect with other minimum implementations, such as Math.min().
I think the vectorclock.minimum() function is only used by the
batching code. Also, I modified the spot where the vector clock is
first initialized so we explicitly store a '0' clock when we first
push data.

This seems to fix the main problem I was seeing with the
collaboration-random test not finishing (#246). However, I am still seeing
it happen, but less often, so I will need to investigate some more.

There definitely needs to be some more test cases for how we want
deltas and clocks to combine into batches.
