### PR TITLE
Lock aegir version

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "vectorclock": "0.0.0"
   },
   "devDependencies": {
-    "aegir": "^18.0.3",
+    "aegir": "18.0.3",
     "babel-eslint": "^10.0.1",
     "bs58": "^4.0.1",
     "chai": "^4.2.0",


### PR DESCRIPTION
Newer versions of aegir cause `npm test` to fail because stream-to-pull-stream
1.7.2 has two 'destroy' methods (fixed in 1.7.3). We're stuck on 1.7.2
until js-ipfs is updated.