### PR TITLE
Join state after load with initial state

### DIFF
--- a/src/collaboration/shared.js
+++ b/src/collaboration/shared.js
@@ -70,7 +70,7 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
         assert(!valueCache)
         valueCache = crdtType.incrementalValue(state, loadedState, loadedState)
       }
-      state = loadedState
+      state = crdtType.join.call(changeEmitter, state, loadedState)
     } else if (crdtType.incrementalValue && !options.replicateOnly) {
       assert(!valueCache)
       valueCache = crdtType.incrementalValue(state, state, state)


### PR DESCRIPTION
When loading an ORMap, it wasn't setting the CausalContext properly
when only being deserialized.