### PR TITLE
minor fixes: swap peer-star-app to peer-base

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -80,7 +80,7 @@ Keys can be used to collaborate. If provided, they authenticate changes to the c
 ### `await Keys.generate()`
 
 ```js
-const Keys = require('peer-star-app').keys
+const Keys = require('peer-base').keys
 
 const keys = await Keys.generate()
 ```
@@ -90,7 +90,7 @@ const keys = await Keys.generate()
 Encode keys into a URI-acceptable string:
 
 ```js
-const Keys = require('peer-star-app').keys
+const Keys = require('peer-base').keys
 const keys = await Keys.generate()
 
 const string = Keys.uriEncode(keys)
@@ -101,7 +101,7 @@ const string = Keys.uriEncode(keys)
 Encode the read-only key into a URI-acceptable string:
 
 ```js
-const Keys = require('peer-star-app').keys
+const Keys = require('peer-base').keys
 const keys = await Keys.generate()
 
 const string = Keys.uriEncodeReadOnly(keys)
@@ -112,7 +112,7 @@ const string = Keys.uriEncodeReadOnly(keys)
 Decode keys from a string:
 
 ```js
-const Keys = require('peer-star-app').keys
+const Keys = require('peer-base').keys
 const keys = await Keys.generate()
 
 const string = Keys.uriEncode(keys)
@@ -125,7 +125,7 @@ const decodedKeys = await Keys.uriDecode(string)
 You can distribute a read-only key by using `PeerBase.keys.uriEncodeReadOnly(keys)`:
 
 ```js
-const Keys = require('peer-star-app').keys
+const Keys = require('peer-base').keys
 const keys = await Keys.generate()
 
 const string = Keys.uriEncodeReadOnly(keys)
@@ -134,7 +134,7 @@ const string = Keys.uriEncodeReadOnly(keys)
 ### Generate symmetrical key
 
 ```js
-const Keys = require('peer-star-app').keys
+const Keys = require('peer-base').keys
 
 // options are optional. defaults to:
 const options = {
@@ -511,7 +511,7 @@ If you want to know or change the way that peer-star persists the collaboration 
 
 ## IPFS Circuit Relay support
 
-Peer-star-app supports using a circuit relay peer. For that you need to set up a go-ipfs node with circuit relay enabled. On your peer-star-app options, you can then pass in `options.ipfs.relay` with an object with the following attributes:
+peer-base supports using a circuit relay peer. For that you need to set up a go-ipfs node with circuit relay enabled. On your peer-base options, you can then pass in `options.ipfs.relay` with an object with the following attributes:
 
 * `relayWSAddr`: the multiaddress for the websocket server of the relay server
 * `apiAddr`: the multiaddress for the relay server API address (which we need for polling the known peers)
@@ -550,7 +550,7 @@ Emitted when a collaboration stops (probably because of innactivity).
 To install a pinner you can:
 
 ```sh
-$ npm install -g peer-star-app
+$ npm install -g peer-base
 $ PEER_STAR_APP_NAME=my-app-name pinner
 ```
 

--- a/docs/CODE-STRUCTURE.md
+++ b/docs/CODE-STRUCTURE.md
@@ -1,4 +1,4 @@
-# peer-star-app - Code structure explanation
+# peer-base - Code structure explanation
 
 ```
 src/
@@ -36,7 +36,7 @@ src/
 
 ## `src/app.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/app.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/app.js)
 
 Represents the application. Has a name (should be unique in the universe). After instantiated, ot should be started.
 
@@ -48,7 +48,7 @@ Delivers membership gossip messages to each one of the registered collaborations
 
 ## `src/peer-count-guess.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/app.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/app.js)
 
 Observes overall gossip observed by the application (by listening to the app `gossip` event).
 
@@ -58,7 +58,7 @@ using that, for each gossip message, it extracts the source peer id and adds it 
 
 ### `src/common/ring.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/common/ring.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/common/ring.js)
 
 A hash ring of peers. Peers can be added, removed, and inquired if they belong.
 
@@ -68,7 +68,7 @@ Does all this by maintaining a sorted list of peers (points in the ring).
 
 ### `src/common/dias-peer-set.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/common/dias-peer-set.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/common/dias-peer-set.js)
 
 Given a ring and a peer id (the self peer id), it computes the set of peers that are in the following positions:
 
@@ -81,19 +81,19 @@ Given a ring and a peer id (the self peer id), it computes the set of peers that
 
 ### `src/common/peer-set.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/common/peer-set.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/common/peer-set.js)
 
 As a Set, but only for `PeerInfo` instances. Uniqueness by peer id. Exposes the JS `Set` API.
 
 ### `src/common/encode.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/common/encode.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/common/encode.js)
 
 Encodes data to be sent over the wire and stored. Uses msgpack for that.
 
 ### `src/common/decode.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/common/decode.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/common/decode.js)
 
 Decodes data from the network and storage. Uses msgpack for that.
 
@@ -103,7 +103,7 @@ Everything pertaining to app-wide transport and discovery, interfacing with libp
 
 ### `src/transport/ipfs.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/transport/ipfs.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/transport/ipfs.js)
 
 Creates the js-IPFS node. When doing that, it instantiates the AppTransport (see later) and defines that as the transport module.
 
@@ -111,7 +111,7 @@ It relays some app-transport events into the app itself.
 
 ### `src/transport/app-transport.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/transport/app-transport.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/transport/app-transport.js)
 
 Wraps the original libp2p transport. Creates a ring from the discovered nodes. Maintains a list of inbound and outbound connections. Connects all these into the global connection manager (explained later).
 
@@ -121,7 +121,7 @@ Instantiates a connection manager that maintains connections to a subset of node
 
 ### `src/transport/discovery.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/transport/discovery.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/transport/discovery.js)
 
 Wraps the native transport discovery and filters discovery events.
 
@@ -135,7 +135,7 @@ If the peer is interested, it's added to the hash ring. Otherwise, the peer is d
 
 ### `src/transport/global-connection-manager.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/transport/global-connection-manager.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/transport/global-connection-manager.js)
 
 Manages app-wide connections to other peers. It does that by keeping a list of inbound and outbound connections and a lust of collaborations per peer.
 
@@ -147,14 +147,14 @@ Collaboration-specific code.
 
 ### `src/collaboration/index.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/collaboration/index.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/collaboration/index.js)
 
 Internally instantiated by the app. Exposes the internal Collaboration class. It has a collaboration store, keeps track of the collaboration membership (by delegating collaboration-specific membership messages) and helps defining the CRDT type of the collaboration.
 
 
 ### `src/collaboration/membership.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/collaboration/membership.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/collaboration/membership.js)
 
 Keeps tracks of collaboration members. Receives gossip messages from the app and incorporates into the membership set. Has an heuristic to define the frequency of the membership gossip.
 
@@ -163,7 +163,7 @@ Creates the DiasSet definition and passes it down to the collaboration-specific 
 
 ### `src/collaboration/connection-manager.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/collaboration/connection-manager.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/collaboration/connection-manager.js)
 
 Maintains a list of collaboration-specific inbound and outbound connections. Instantiates the protocol (see below). Maintains the ring of known peers passed in from the membership.
 
@@ -171,13 +171,13 @@ When ring changes happen, we debounce that event and then react to it by maintai
 
 ### `src/collaboration/protocol.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/collaboration/protocol.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/collaboration/protocol.js)
 
 Exposes a protocol handler and a dialer. The protocol handler delegates into the pull protocol (see below). The dialer delegates into the push protocol (see below).
 
 ### `src/collaboration/push-protocol.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/collaboration/push-protocol.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/collaboration/push-protocol.js)
 
 For any given peer, is able to create a peer connection-handling stream as a pull stream.
 
@@ -191,7 +191,7 @@ In lazy mode, it only pushes the local store vector clock.
 
 ### `src/collaboration/pull-protocol.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/collaboration/pull-protocol.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/collaboration/pull-protocol.js)
 
 For any given peer, is able to create a peer connection-handling stream as a pull stream.
 
@@ -204,7 +204,7 @@ It's also responsible for:
 
 ### `src/collaboration/store.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/collaboration/store.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/collaboration/store.js)
 
 Collaboration store. Wraps the IPFS data store into a collaboration-specific namespace.
 
@@ -218,7 +218,7 @@ Uses the shared CRDT (see below) to merge states and deltas to form the new stat
 
 ### `src/collaboration/shared.js`
 
-[Link](https://github.com/ipfs-shipyard/peer-star-app/blob/master/src/collaboration/shared.js)
+[Link](https://github.com/ipfs-shipyard/peer-base/blob/master/src/collaboration/shared.js)
 
 Exposes to the user the `collaboration.shared` API, where you have:
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,4 +1,4 @@
-# peer-star-app - Protocol explanation
+# peer-base - Protocol explanation
 
 ## Discovery
 

--- a/examples/react-app/README.md
+++ b/examples/react-app/README.md
@@ -5,7 +5,7 @@
 Clone this repo.
 
 ```bash
-$ cd peer-star-app
+$ cd peer-base
 $ cd examples/react-app
 $ npm install
 ```

--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "fast-diff": "^1.2.0",
     "libp2p-websocket-star-rendezvous": "^0.3.0",
-    "peer-star-app": "../../",
+    "peer-base": "../../",
     "peer-star-network-vis-react": "^0.1.3",
     "peer-star-react": "^0.1.0",
     "react": "^16.5.2",

--- a/examples/react-app/src/App.js
+++ b/examples/react-app/src/App.js
@@ -3,7 +3,7 @@ import { HashRouter as Router, Route, Link } from 'react-router-dom'
 import logo from './logo.svg'
 import './App.css'
 
-import PeerStarApp from 'peer-star-app'
+import PeerStarApp from 'peer-base'
 
 import Home from './Home'
 import routes from './routes'

--- a/examples/react-app/src/CreateKey.js
+++ b/examples/react-app/src/CreateKey.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { Redirect } from 'react-router-dom'
-import PeerStar, { keys as Keys } from 'peer-star-app'
+import PeerStar, { keys as Keys } from 'peer-base'
 
 export default class CreateKey extends Component {
   state = {}

--- a/examples/react-app/src/DiscussionTreeCollaboration.js
+++ b/examples/react-app/src/DiscussionTreeCollaboration.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PeerStarApp from 'peer-star-app'
+import PeerStarApp from 'peer-base'
 import NetworkVis from 'peer-star-network-vis-react'
 import discussionTreeCrdt from './lib/discussion-tree-crdt'
 import CollaborationStats from './CollaborationStats'


### PR DESCRIPTION
This minor fix will resolve the compilation error : 

    Failed to compile.
    ./node_modules/peer-star-react/src/withCollaboration.js
    Module not found: Can't resolve 'peer-star-app' in '/home/peer-base/examples/react- 
    app/node_modules/peer-star-react/src'

