### PR TITLE
Expose shared.applyAndPushDelta method

### DIFF
--- a/src/collaboration/shared.js
+++ b/src/collaboration/shared.js
@@ -163,6 +163,8 @@ module.exports = (name, id, crdtType, ipfs, collaboration, clocks, options) => {
     return (vectorclock.compare(otherClock, clock) < 0) || vectorclock.isIdentical(otherClock, clock)
   }
 
+  shared.applyAndPushDelta = applyAndPushDelta
+
   shared.deltas = (since = {}, targetPeerId) => {
     return deltas.filter((deltaRecord) => {
       if (vectorclock.isDeltaInteresting(deltaRecord, since, targetPeerId)) {


### PR DESCRIPTION
In a `peer-base` application I'm working on, the user begins in a completely 'offline' environment, in which state is stored natively using raw [delta-crdts](https://github.com/ipfs-shipyard/js-delta-crdts).

Users can then choose to begin (and/or later leave) a collaborative session, either by invitation or by starting one themselves.

At this point a bi-directional sync process is started - event listeners for `local.on('state changed')` and `network.on('state changed')` relay local and peer state updates between each other.  This has the nice property that the application state management is completely unaware of the network object and state.  And the CRDTs (as they are designed to do) naturally handle any conflict resolution.

Using this model required me to expose the `shared.applyAndPushDelta` method on `peer-base` shared CRDTs, since this approach requires an interface to propagate locally-applied changes to the network-aware CRDT.

cc @jimpick 